### PR TITLE
Notify predecessor after stabilize

### DIFF
--- a/dht.h
+++ b/dht.h
@@ -78,6 +78,8 @@ extern struct peer self;
  */
 extern struct peer successor;
 
+extern struct peer NULL_PEER;
+
 /**
  * The socket used for communicating with the DHT
  */

--- a/webserver.c
+++ b/webserver.c
@@ -393,6 +393,7 @@ int main(int argc, char** argv) {
 
     if (join_mode) {
         struct peer peer = peer_from_args("0", argv[4], argv[5]);
+        // predecessor = NULL_PEER;
         dht_join(self, peer);
     };
 


### PR DESCRIPTION
The fact that the test 2 fails is to be expected. There is a way to ignore it, but not quite sure how.

> Als Workaround setzen diese Tests die NO_STABILIZE
Umgebungsvariable. Dies erlaubt, das Senden von Stabilize Nachrichten in diesem Fall
zu deaktivieren. Dies ist allerdings optional, Ihre Abgabe wird nur anhand der Tests für
Praxis 3 bewertet.